### PR TITLE
Remove outdated documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ var dispatch = d3.dispatch("start", "end");
 
 <a name="dispatch" href="#dispatch">#</a> d3.<b>dispatch</b>(<i>types…</i>) [<>](https://github.com/d3/d3-dispatch/blob/master/src/dispatch.js "Source")
 
-Creates a new dispatch for the specified event *types*. Each *type* is a string, such as `"start"` or `"end"`; for each type, [a method](#dispatch_type) is exposed on the returned dispatch for invoking the callbacks of that type.
+Creates a new dispatch for the specified event *types*. Each *type* is a string, such as `"start"` or `"end"`.
 
 <a name="dispatch_on" href="#dispatch_on">#</a> *dispatch*.<b>on</b>(<i>typenames</i>[, <i>callback</i>]) [<>](https://github.com/d3/d3-dispatch/blob/master/src/dispatch.js#L26 "Source")
 


### PR DESCRIPTION
I noticed the documentation still mentioned that each type is exposed as a method on the dispatcher, but this is actually no longer true (I wish it were, that was a nice API to use as compared to the current `call` method, which requires a `this` parameter when using arguments even if `this` is not needed in the listeners).