### PR TITLE
Allow spaced types and forbid periods in types.

### DIFF
--- a/src/dispatch.js
+++ b/src/dispatch.js
@@ -1,9 +1,11 @@
 var noop = {value: function() {}};
 
 function dispatch() {
-  for (var i = 0, n = arguments.length, _ = {}, t; i < n; ++i) {
-    if (!(t = arguments[i] + "") || (t in _)) throw new Error("illegal type: " + t);
-    _[t] = [];
+  for (var i = 0, n = arguments.length, _ = {}; i < n; ++i) {
+    (arguments[i] + "").trim().split(/\s+/).forEach(function(t) {
+      if (!t || (t in _) || t.indexOf(".") >= 0) throw new Error("illegal type: " + t);
+      _[t] = [];
+    });
   }
   return new Dispatch(_);
 }

--- a/test/dispatch-test.js
+++ b/test/dispatch-test.js
@@ -8,6 +8,14 @@ tape("dispatch(type…) returns a dispatch object with the specified types", fun
   test.end();
 });
 
+tape("dispatch(type…) allows space separated types", function(test) {
+  var d = dispatch.dispatch("foo bar");
+  test.doesNotThrow(function() { d.on("foo", null); })
+  test.doesNotThrow(function() { d.on("bar", null); })
+  test.throws(function() { d.on("baz", null); })
+  test.end();
+});
+
 tape("dispatch(type…) does not throw an error if a specified type name collides with a dispatch method", function(test) {
   var d = dispatch.dispatch("on");
   test.ok(d instanceof dispatch.dispatch);
@@ -18,6 +26,13 @@ tape("dispatch(type…) throws an error if a specified type name is illegal", fu
   test.throws(function() { dispatch.dispatch("__proto__"); });
   test.throws(function() { dispatch.dispatch("hasOwnProperty"); });
   test.throws(function() { dispatch.dispatch(""); });
+  test.throws(function() { dispatch.dispatch("foo __proto__"); });
+  test.end();
+});
+
+tape("dispatch(type…) throws an error if a specified type name has a period", function(test) {
+  test.throws(function() { dispatch.dispatch("foo.start"); });
+  test.throws(function() { dispatch.dispatch(".foo"); });
   test.end();
 });
 


### PR DESCRIPTION
This pull request allows spaces in dispatch types. So that
```javascript
d3.dispatch("start end");
```
is same as
```javascript
d3.dispatch("start", "end");
```

Also make dispatch throws if a type contains a periods:
```javascript
d3.dispatch("start.foo"); // throws "illegal type"
```

Closes #10.
