### PR TITLE
fix regex bug in IE where parseTypenames didn't always work properly

### DIFF
--- a/src/dispatch.js
+++ b/src/dispatch.js
@@ -13,7 +13,7 @@ function Dispatch(_) {
 }
 
 function parseTypenames(typenames, types) {
-  return typenames.trim().split(/^|\s+/).map(function(t) {
+  return typenames.trim().split(/\s+/).filter(function(t) { return t; }).map(function(t) {
     var name = "", i = t.indexOf(".");
     if (i >= 0) name = t.slice(i + 1), t = t.slice(0, i);
     if (t && !types.hasOwnProperty(t)) throw new Error("unknown type: " + t);


### PR DESCRIPTION
Fixes #18 - updates the regex 

> the regex `/^|\s+/` splits a string into it's individual characters. So something like `"end".trim().split(/^|\s+/)` in Internet Explorer 11 outputs `[ "e", "n", "d" ]`. In modern browsers, it outputs `[ "end" ]` as expected. 

The regex `/\s+/` works in both Internet Explorer 11 and modern browsers. Added a filter that maintains the behavior where it removes empty strings and keeps them from being processed through the map function.